### PR TITLE
OU-147: Add Perses "view" into the web console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,6 @@ start-backend:
 .PHONY: build-image
 build-image:
 	./scripts/build-image.sh
+
+.PHONY: install
+install: install-frontend install-backend

--- a/scripts/start-console.sh
+++ b/scripts/start-console.sh
@@ -39,13 +39,13 @@ echo "Plugin proxy: ${PLUGIN_PROXY}"
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://localhost:9001"
+        BRIDGE_PLUGINS="dashboards-console-plugin=http://localhost:9001"
         podman run --pull always --rm --network=host --env-file <(set | grep BRIDGE) --env BRIDGE_PLUGIN_PROXY="${PLUGIN_PROXY}" $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.containers.internal:9001"
+        BRIDGE_PLUGINS="dashboards-console-plugin=http://host.containers.internal:9001"
         podman run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) --env BRIDGE_PLUGIN_PROXY="${PLUGIN_PROXY}" $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.docker.internal:9001"
+    BRIDGE_PLUGINS="dashboards-console-plugin=http://host.docker.internal:9001"
     docker run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) --env BRIDGE_PLUGIN_PROXY="${PLUGIN_PROXY}" $CONSOLE_IMAGE
 fi

--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -13,5 +13,23 @@
       "contextId": "monitoring-dashboards",
       "getDataSource": { "$codeRef": "GetDatasource" }
     }
+  }, 
+  {
+    "type": "console.navigation/href",
+    "properties": {
+      "id": "monitoringperses",
+      "name": "Perses Dashboards",
+      "href": "/perses-dashboards",
+      "perspective": "admin",
+      "section": "observe"
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties":{
+      "component": { "$codeRef": "PersesPage" },
+      "path":  "/perses-dashboards"
+    }
   }
 ]
+ 

--- a/web/package.json
+++ b/web/package.json
@@ -55,7 +55,8 @@
     "description": "Plugin to add proxy configurations from console to in-cluster services to populate dashboards",
     "exposedModules": {
       "ProxyTestPage": "./components/ProxyTestPage",
-      "GetDatasource": "./getDatasource"
+      "GetDatasource": "./getDatasource",
+      "PersesPage": "./components/PersesPage"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/web/src/components/PersesPage.tsx
+++ b/web/src/components/PersesPage.tsx
@@ -1,0 +1,9 @@
+import * as React from "react"
+
+export default function PersesPage(){
+    return (
+        <div>
+            <h1> hello world </h1>
+        </div>
+    )
+}


### PR DESCRIPTION
**Relates to** 
[OU-147: Add Perses "view" into the web console](https://issues.redhat.com/browse/OU-147)

**Summary** 
1. Update MakeFile with command `make install`
2. Create a route to the new page for Perses Dashboards, `/perses-dashboards`
3. Create a href/button named 'Perses Dashboard' on the console's navigation menu. It is located at : OpenShift Admin Console > Observe > Perses Dashboard.
4. Expose Module, PersesPage
5. Update start-console.sh with new plugin name

**Demo** 




https://user-images.githubusercontent.com/59589720/220772609-60b5fe7d-d214-4903-884f-481897943632.mov

