### PR TITLE
Add Perses deployment and plugin proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It will use the image from `quay.io/gbernal/dashboards-console-plugin:0.0.1` and
 to serve the plugin's assets and proxy to the configured datasources.
 
 ```sh
-helm upgrade -i  dashboards-console-plugin charts/dashboards-console-plugin -n console-dashboards --create-namespace
+helm upgrade -i dashboards-console-plugin charts/dashboards-console-plugin -n console-dashboards --create-namespace
 ```
 
 ## Add a new Datasource

--- a/charts/dashboards-console-plugin/templates/_helpers.tpl
+++ b/charts/dashboards-console-plugin/templates/_helpers.tpl
@@ -26,6 +26,18 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Common labels
+*/}}
+{{- define "openshift-console-perses.labels" -}}
+helm.sh/chart: {{ include "openshift-console-plugin.chart" . }}
+{{ include "openshift-console-perses.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "openshift-console-plugin.selectorLabels" -}}
@@ -36,10 +48,27 @@ app.kubernetes.io/part-of: {{ include "openshift-console-plugin.name" . }}
 {{- end }}
 
 {{/*
-Create the name secret containing the certificate
+Perses selector labels
+*/}}
+{{- define "openshift-console-perses.selectorLabels" -}}
+app: {{ include "openshift-console-perses.name" . }}
+app.kubernetes.io/name: {{ include "openshift-console-perses.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: {{ include "openshift-console-perses.name" . }}
+{{- end }}
+
+{{/*
+Create the name secret containing the perses certificate
 */}}
 {{- define "openshift-console-plugin.certificateSecret" -}}
 {{ default (printf "%s-cert" (include "openshift-console-plugin.name" .)) .Values.plugin.certificateSecretName }}
+{{- end }}
+
+{{/*
+Create the name secret containing the plugin certificate
+*/}}
+{{- define "openshift-console-perses.certificateSecret" -}}
+{{ default (printf "%s-cert" (include "openshift-console-perses.name" .)) .Values.perses.certificateSecretName }}
 {{- end }}
 
 {{/*
@@ -76,4 +105,11 @@ Create the name of the configmap reader
 */}}
 {{- define "openshift-console-plugin.configMapReaderName" -}}
 {{- printf "%s-configmap-reader" (include "openshift-console-plugin.name" .) }}
+{{- end }}
+
+{{/*
+Create the name for perses
+*/}}
+{{- define "openshift-console-perses.name" -}}
+{{- default (default .Chart.Name .Release.Name) .Values.perses.name | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/charts/dashboards-console-plugin/templates/configMap.yaml
+++ b/charts/dashboards-console-plugin/templates/configMap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openshift-console-perses.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "openshift-console-plugin.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    error_log /dev/stdout info;
+    pid       /tmp/nginx.pid;
+
+    events {}
+    http {
+      access_log         /dev/stdout;
+      include            /etc/nginx/mime.types;
+      default_type       application/octet-stream;
+      keepalive_timeout  65;
+      client_body_temp_path /tmp/nginx-client-body;
+      proxy_temp_path       /tmp/nginx-proxy;
+      fastcgi_temp_path     /tmp/nginx-fastcgi;
+      uwsgi_temp_path       /tmp/nginx-uwsgi;
+      scgi_temp_path        /tmp/nginx-scgi;
+
+      server {
+        listen              9443 ssl;
+        ssl_certificate     /var/cert/tls.crt;
+        ssl_certificate_key /var/cert/tls.key;
+
+        location / {
+          proxy_set_header Cookie $http_cookie;
+          proxy_pass http://localhost:8080/;
+        }
+      }
+    }

--- a/charts/dashboards-console-plugin/templates/consoleplugin.yaml
+++ b/charts/dashboards-console-plugin/templates/consoleplugin.yaml
@@ -20,3 +20,10 @@ spec:
         name: {{ template "openshift-console-plugin.name" . }}
         namespace: {{ .Release.Namespace }}
         port: {{ .Values.plugin.port }}
+    - type: Service
+      alias: perses
+      authorize: true
+      service:
+        name: {{ template "openshift-console-perses.name" . }}
+        namespace: {{ .Release.Namespace }}
+        port: 9443

--- a/charts/dashboards-console-plugin/templates/perses-deployment.yaml
+++ b/charts/dashboards-console-plugin/templates/perses-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openshift-console-perses.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-perses.labels" . | nindent 4 }}
+    app.openshift.io/runtime-namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "openshift-console-perses.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+            {{- include "openshift-console-perses.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: perses-proxy
+          image: docker.io/nginx:latest
+          ports:
+            - containerPort: 9443
+              protocol: TCP
+          imagePullPolicy: {{ .Values.perses.imagePullPolicy }}
+          {{- if and (.Values.perses.securityContext.enabled) (.Values.perses.containerSecurityContext) }}
+          securityContext: {{ tpl (toYaml (omit .Values.perses.containerSecurityContext "enabled")) $ | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.perses.resources | nindent 12 }}
+          volumeMounts:
+            - name: {{ template "openshift-console-perses.certificateSecret" . }}
+              readOnly: true
+              mountPath: /var/cert
+            - name: nginx-conf
+              readOnly: true
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+        - name: {{ template "openshift-console-perses.name" . }}
+          image: {{ required "Perses image must be specified!" .Values.perses.image }}
+          ports:
+            - containerPort: {{ .Values.perses.port }}
+              protocol: TCP
+          imagePullPolicy: {{ .Values.perses.imagePullPolicy }}
+          {{- if and (.Values.perses.securityContext.enabled) (.Values.perses.containerSecurityContext) }}
+          securityContext: {{ tpl (toYaml (omit .Values.perses.containerSecurityContext "enabled")) $ | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.perses.resources | nindent 12 }}
+      volumes:
+        - name: {{ template "openshift-console-perses.certificateSecret" . }}
+          secret:
+            secretName: {{ template "openshift-console-perses.certificateSecret" . }}
+            defaultMode: 420
+        - name: nginx-conf
+          configMap:
+            name: {{ template "openshift-console-perses.name" . }}
+            defaultMode: 420
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      {{- if and (.Values.perses.securityContext.enabled) (.Values.perses.podSecurityContext) }}
+      securityContext: {{ tpl (toYaml (omit .Values.perses.podSecurityContext "enabled")) $ | nindent 8 }}
+      {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%

--- a/charts/dashboards-console-plugin/templates/perses-service.yaml
+++ b/charts/dashboards-console-plugin/templates/perses-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if not .Values.certificateSecretName }}
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: {{ template "openshift-console-perses.certificateSecret" . }}
+  {{- end }}
+  name: {{ template "openshift-console-perses.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openshift-console-perses.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: web
+      protocol: TCP
+      port: 9443
+      targetPort: 9443
+  selector:
+    {{- include "openshift-console-perses.selectorLabels" . | nindent 4 }}
+  type: ClusterIP
+  sessionAffinity: None

--- a/charts/dashboards-console-plugin/values.yaml
+++ b/charts/dashboards-console-plugin/values.yaml
@@ -1,10 +1,34 @@
 ---
+perses:
+  name: "dashboards-console-perses"
+  image: "docker.io/persesdev/perses:latest"
+  imagePullPolicy: Always
+  replicas: 1
+  port: 8080
+  securityContext:
+    enabled: true
+  podSecurityContext:
+    enabled: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  resources:
+    requests:
+      cpu: 10m
+      memory: 50Mi
+  certificateSecretName: "perses-serving-cert"
 plugin:
   name: "dashboards-console-plugin"
   description: ""
-  image: "quay.io/gbernal/dashboards-console-plugin:0.0.1"
+  image: "quay.io/gbernal/dashboards-console-plugin:dev"
   imagePullPolicy: Always
-  replicas: 2
+  replicas: 1
   port: 9443
   securityContext:
     enabled: true

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -2,20 +2,10 @@
 
 set -euo pipefail
 
-PREFER_PODMAN=0
-PUSH=0
-TAG="0.0.1"
-REGISTRY_ORG="gbernal"
-
-while getopts ":pto:" flag; do
-    case $flag in
-        p) PREFER_PODMAN=1;;
-        t) TAG=$OPTARG;;
-        o) REGISTRY_ORG=$OPTARG;;
-        \?) echo "Invalid option: -$flag" 
-            exit;;
-    esac
-done
+PREFER_PODMAN="${PREFER_PODMAN:-0}"
+PUSH="${PUSH:-0}"
+TAG="${TAG:-0.0.1}"
+REGISTRY_ORG="${REGISTRY_ORG:-gbernal}"
 
 if [[ -x "$(command -v podman)" && $PREFER_PODMAN == 1 ]]; then
     OCI_BIN="podman"
@@ -28,3 +18,7 @@ IMAGE=${BASE_IMAGE}:${TAG}
 
 echo "Building image '${IMAGE}' with ${OCI_BIN}"
 $OCI_BIN build -t $IMAGE .
+
+if [[ $PUSH == 1 ]]; then
+    $OCI_BIN push $IMAGE
+fi


### PR DESCRIPTION
https://issues.redhat.com/browse/OU-152

This PR adds:

- Perses as a new deployment in the `console-dashboards` namespace, same as the plugin
- Adds a proxy configuration so the console can consume Perses API through the plugin